### PR TITLE
Implement optional rent payer

### DIFF
--- a/programs/sol-gateway/src/lib.rs
+++ b/programs/sol-gateway/src/lib.rs
@@ -11,7 +11,7 @@ pub mod instructions;
 pub mod state;
 pub mod utils;
 
-declare_id!("6CvJLL1q7A9vD97jHGtr8EX7LoaPEP51HH2ab2JLUn9m");
+declare_id!("C8TANLzc5UKGQBzhmKjrs7nAB326zxoBFtJ9x48C5S6Z");
 
 #[program]
 pub mod sol_gateway {

--- a/programs/sol-gateway/src/state/file.rs
+++ b/programs/sol-gateway/src/state/file.rs
@@ -41,7 +41,7 @@ pub struct UpdateFileData {
     pub size: Option<u64>,
     pub checksum: String,
     pub account_type: u8,
-    pub expires_at: i64,
+    pub expires_at: Option<i64>,
 }
 
 #[account]

--- a/programs/sol-gateway/src/utils/file.rs
+++ b/programs/sol-gateway/src/utils/file.rs
@@ -79,7 +79,7 @@ mod tests {
             size: 0,
             checksum: "test".to_string(),
             account_type: AccountTypes::Basic as u8,
-            expires_at: None,
+            expires_at: 0,
         };
         assert_eq!(get_fee(&file), if FEE.is_some() { FEE.unwrap() } else { 0 });
         file.fee = Some(10);

--- a/tests/3_assign_roles.ts
+++ b/tests/3_assign_roles.ts
@@ -7,7 +7,9 @@ import {
   PROGRAM,
   PROVIDER,
   ALLOWED_WALLET,
+  ANOTHER_WALLET,
 } from "./constants";
+import * as anchor from "@project-serum/anchor";
 
 describe("3.- Assign roles", () => {
   let filePDA = null; // Populated on before() block
@@ -17,10 +19,7 @@ describe("3.- Assign roles", () => {
   });
 
   it("Assign role to File", async () => {
-    const rolePDA = await role_pda(
-      WRITE_PERM.role,
-      PROVIDER.wallet.publicKey
-    );
+    const rolePDA = await role_pda(WRITE_PERM.role, PROVIDER.wallet.publicKey);
     const oneHourLater = Math.floor(new Date().getTime() / 1000) + 60 * 60;
     let listener = null;
     let [event, _]: any = await new Promise((resolve, reject) => {
@@ -52,12 +51,13 @@ describe("3.- Assign roles", () => {
 
     const role = await PROGRAM.account.role.fetch(rolePDA);
     expect(FILE_ID.toBase58()).to.equal(event.fileId.toBase58());
-   
+
     expect(role.role).to.equal(WRITE_PERM.role);
     expect(role.addressType).to.deep.equal(addressType.Wallet);
     expect(role.expiresAt.toNumber()).to.equal(oneHourLater);
   });
 
+  // TODO: fix this test
   it("Assign role to Wallet", async () => {
     const rolePDA = await role_pda(WRITE_PERM.role, ALLOWED_WALLET.publicKey);
     await PROGRAM.methods
@@ -79,6 +79,66 @@ describe("3.- Assign roles", () => {
       .rpc();
   });
 
+  it("Assign role to Wallet (w/ different rent payer)", async () => {
+    let listener = PROGRAM.addEventListener("RolesChanged", (event, slot) => {
+      expect(FILE_ID.toBase58()).to.equal(event.fileId.toBase58());
+      PROGRAM.removeEventListener(listener);
+    });
+
+    const permissionedWallet = anchor.web3.Keypair.generate();
+    const rolePDA = await role_pda(
+      WRITE_PERM.role,
+      permissionedWallet.publicKey
+    );
+    const oneHourLater = Math.floor(Date.now() / 1000) + 60 * 60;
+
+    let tx = await PROGRAM.methods
+      .assignRole({
+        address: permissionedWallet.publicKey,
+        role: WRITE_PERM.role,
+        addressType: addressType.Wallet,
+        expiresAt: new BN(oneHourLater),
+      })
+      .accounts({
+        role: rolePDA,
+        solGatewayFile: filePDA,
+        solGatewayRole: null,
+        solGatewayRule: null,
+        solGatewayToken: null,
+        solGatewayMetadata: null,
+        solGatewaySeed: null,
+        rentPayer: ANOTHER_WALLET.publicKey,
+      })
+      .signers([ANOTHER_WALLET])
+      .transaction();
+
+    // Implement manual fee payer and transaction processing (encapsulated by Anchor's implementation by default)
+    tx.feePayer = ANOTHER_WALLET.publicKey;
+    tx.recentBlockhash = (
+      await PROVIDER.connection.getLatestBlockhash()
+    ).blockhash;
+    tx.partialSign(ANOTHER_WALLET);
+
+    tx = await PROVIDER.wallet.signTransaction(tx);
+    const rawTx = tx.serialize();
+
+    // Send transaction and confirm
+    // TODO: Check if this is the correct way to send a raw transaction
+    const txResponse = await PROVIDER.connection.sendRawTransaction(rawTx);
+    await PROVIDER.connection.confirmTransaction(txResponse, "confirmed");
+
+    const role = await PROGRAM.account.role.fetch(rolePDA);
+
+    expect(role.fileId.toBase58()).to.equal(FILE_ID.toBase58());
+    expect(role.role).to.equal(WRITE_PERM.role);
+    expect(role.addressType).to.deep.equal(addressType.Wallet);
+    expect(role.expiresAt.toNumber()).to.equal(oneHourLater);
+    expect(role.address.toBase58()).to.equal(
+      permissionedWallet.publicKey.toBase58()
+    );
+  });
+
+  // TODO: remove this possibility
   it("Assign role to All", async () => {
     const rolePDA = await role_pda(READ_PERM.role, null);
     await PROGRAM.methods

--- a/tests/5_allow_assign_roles.ts
+++ b/tests/5_allow_assign_roles.ts
@@ -61,7 +61,7 @@ describe("5.- Allow assign roles", () => {
           solGatewayToken: null,
           solGatewayMetadata: null,
           solGatewaySeed: allowedWalletSeedPDA,
-          signer: ALLOWED_WALLET.publicKey,
+          contributor: ALLOWED_WALLET.publicKey,
         })
         .signers([ALLOWED_WALLET])
         .rpc();
@@ -118,7 +118,7 @@ describe("5.- Allow assign roles", () => {
         solGatewayToken: null,
         solGatewayMetadata: null,
         solGatewaySeed: allowedWalletSeedPDA,
-        signer: ALLOWED_WALLET.publicKey,
+        contributor: ALLOWED_WALLET.publicKey,
       })
       .signers([ALLOWED_WALLET])
       .rpc();


### PR DESCRIPTION
## What's changed

- Added `rent_payer` field to `initialize_file` and `assign_role` instructions
  - Created respective unit tests
- Fix: expiration date on update and create file
- Chore: rename fields/improve unit tests

## References

- Marinade Finance (Liquid Stake): https://github.com/marinade-finance/liquid-staking-program/blob/26147376b75d8c971963da458623e646f2795e15/programs/marinade-finance/src/instructions/user/withdraw_stake_account.rs#L86
- Kamino Finance (lending/obligation): https://github.com/Kamino-Finance/klend/blob/master/programs/klend/src/handlers/handler_init_obligation.rs